### PR TITLE
Handle non-WouldBlock errors in `smoltcp::phy::Device`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = 'probe-run'
+runner = 'probe-rs run'
 rustflags = [
   "-C", "link-arg=-Tlink.x",
   "-C", "link-arg=-Tdefmt.x",


### PR DESCRIPTION
While investigating #100, I realized that `unwrap` comment was correct, but incomplete: `WouldBlock` is not the only error that can occur.

Instead of `unwrap()`-ing, actually handle all error cases and print appropriate messages.