### PR TITLE
examples: set up MPU for all examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Unreleased
 
 * Fix a bug where errors on receive could cause RX stalls ([#108])
+* Always disable cache for the RAM used for example code ([#107])
 
 [#108]: https://github.com/stm32-rs/stm32-eth/pull/108
+[#107]: https://github.com/stm32-rs/stm32-eth/pull/107
 
 ## [0.8.2](https://github.com/stm32-rs/stm32-eth/tree/v0.8.2)
 * Implement `smoltcp::phy::Device` for non-borrowed `EthernetDMA` ([#106])

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ fn main() {
         rx_d1: gpioc.pc5,
     };
 
+    // If your MCU's core has caching support (generally true for M7 cores), make sure
+    // to mark the memory for the following two arrays as non-cacheable using
+    // the `cortex_m::peripheral::MPU`.
     let mut rx_ring: [RxRingEntry; 16] = Default::default();
     let mut tx_ring: [TxRingEntry; 8] = Default::default();
 

--- a/examples/arp.rs
+++ b/examples/arp.rs
@@ -35,16 +35,17 @@ fn main() -> ! {
     let p = Peripherals::take().unwrap();
     let mut cp = CorePeripherals::take().unwrap();
 
-    let (clocks, gpio, ethernet) = common::setup_peripherals(p);
+    let mut rx_ring: [RxRingEntry; 2] = Default::default();
+    let mut tx_ring: [TxRingEntry; 2] = Default::default();
+
+    let (clocks, gpio, ethernet) =
+        common::setup_peripherals_and_cache(p, cp.MPU, &rx_ring, &tx_ring);
 
     setup_systick(&mut cp.SYST);
 
     defmt::info!("Enabling ethernet...");
 
     let (eth_pins, mdio, mdc, _) = common::setup_pins(gpio);
-
-    let mut rx_ring: [RxRingEntry; 2] = Default::default();
-    let mut tx_ring: [TxRingEntry; 2] = Default::default();
 
     let Parts {
         mut dma,

--- a/examples/async-rtic-timestamp.rs
+++ b/examples/async-rtic-timestamp.rs
@@ -81,7 +81,8 @@ mod app {
         let rx_ring = cx.local.rx_ring;
         let tx_ring = cx.local.tx_ring;
 
-        let (clocks, gpio, ethernet) = crate::common::setup_peripherals(p);
+        let (clocks, gpio, ethernet) =
+            crate::common::setup_peripherals_and_cache(p, cx.core.MPU, rx_ring, tx_ring);
 
         defmt::info!("Setting up pins");
         let (pins, mdio, mdc, pps) = crate::common::setup_pins(gpio);

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -10,7 +10,9 @@ use defmt_rtt as _;
 use panic_probe as _;
 
 use stm32_eth::{
+    dma::{RxRingEntry, TxRingEntry},
     hal::{gpio::GpioExt, rcc::Clocks},
+    stm32::MPU,
     PartsIn,
 };
 
@@ -25,12 +27,79 @@ use stm32_eth::hal::rcc::RccExt;
 #[allow(unused)]
 fn main() {}
 
+/// Mark RAM as non-cachable. Also validate that the RX ring
+/// and TX ring are within them.
+///
+/// On cores without cache (e.g. M33), this function is a no-op. For cores
+/// with a cache (e.g. M7), this is necessary to ensure that the data read
+/// by the ethernet DMA is the data that the core actually wrote.
+fn mpu_mark_noncachable(mpu: MPU, rx_ring: &[RxRingEntry], tx_ring: &[TxRingEntry]) {
+    let start = 0x20000000u32;
+    let len = 32u32 * 1024;
+    let range = start as usize..(start as usize + len as usize);
+
+    let rx_start = rx_ring.as_ptr();
+    let rx_first_addr = rx_start.addr();
+    let rx_last_addr = unsafe { rx_start.add(rx_ring.len() + 1) }.addr() - 1;
+    assert!(
+        range.contains(&rx_first_addr),
+        "RX ring starts before non-cacheable region"
+    );
+
+    assert!(
+        range.contains(&rx_last_addr),
+        "RX ring ends after non-cacheable region"
+    );
+
+    let tx_start = tx_ring.as_ptr();
+    let tx_first_addr = tx_start.addr();
+    let tx_last_addr = unsafe { rx_start.add(tx_ring.len() + 1) }.addr() - 1;
+    assert!(
+        range.contains(&tx_first_addr),
+        "TX ring starts before non-cacheable region"
+    );
+
+    assert!(
+        range.contains(&tx_last_addr),
+        "TX ring ends after non-cacheable region"
+    );
+
+    let size_field = len.trailing_zeros() - 1;
+
+    unsafe {
+        mpu.ctrl.write(0);
+        let region = 0;
+        mpu.rnr.write(region);
+        mpu.rbar.write(start | 1 << 4 | region);
+
+        mpu.rasr.write(
+            (1 << 28)       // XN
+        | (0b011 << 24)     // AP = full access
+        | (0b001 << 19)     // TEX = 001 \
+        | (0 << 17)         //   C = 0    } -> Normal, Non-cacheable
+        | (0 << 16)         //   B = 0   /
+        | (size_field << 1) // SIZE
+        | (1 << 0), // ENABLE
+        );
+    }
+
+    cortex_m::asm::dsb();
+    cortex_m::asm::isb();
+}
+
 /// Setup the clocks and return clocks and a GPIO struct that
 /// can be used to set up all of the pins.
 ///
 /// This configures HCLK to be at least 25 MHz, which is the minimum required
 /// for ethernet operation to be valid.
-pub fn setup_peripherals(p: stm32_eth::stm32::Peripherals) -> (Clocks, Gpio, PartsIn) {
+pub fn setup_peripherals_and_cache(
+    p: stm32_eth::stm32::Peripherals,
+    mpu: MPU,
+    rx_ring: &[RxRingEntry],
+    tx_ring: &[TxRingEntry],
+) -> (Clocks, Gpio, PartsIn) {
+    mpu_mark_noncachable(mpu, rx_ring, tx_ring);
+
     let ethernet = PartsIn {
         dma: p.ETHERNET_DMA,
         mac: p.ETHERNET_MAC,

--- a/examples/ip.rs
+++ b/examples/ip.rs
@@ -38,7 +38,11 @@ fn main() -> ! {
     let p = Peripherals::take().unwrap();
     let mut cp = CorePeripherals::take().unwrap();
 
-    let (clocks, gpio, ethernet) = common::setup_peripherals(p);
+    let mut rx_ring: [RxRingEntry; 2] = Default::default();
+    let mut tx_ring: [TxRingEntry; 2] = Default::default();
+
+    let (clocks, gpio, ethernet) =
+        common::setup_peripherals_and_cache(p, cp.MPU, &rx_ring, &tx_ring);
 
     setup_systick(&mut cp.SYST);
 
@@ -46,8 +50,6 @@ fn main() -> ! {
 
     let (eth_pins, _mdio, _mdc, _) = common::setup_pins(gpio);
 
-    let mut rx_ring: [RxRingEntry; 2] = Default::default();
-    let mut tx_ring: [TxRingEntry; 2] = Default::default();
     let Parts {
         mut dma,
         mac: _,

--- a/examples/pktgen.rs
+++ b/examples/pktgen.rs
@@ -35,15 +35,17 @@ fn main() -> ! {
     let p = Peripherals::take().unwrap();
     let mut cp = CorePeripherals::take().unwrap();
 
-    let (clocks, gpio, ethernet) = common::setup_peripherals(p);
+    let mut rx_ring: [RxRingEntry; 2] = Default::default();
+    let mut tx_ring: [TxRingEntry; 2] = Default::default();
+
+    let (clocks, gpio, ethernet) =
+        common::setup_peripherals_and_cache(p, cp.MPU, &rx_ring, &tx_ring);
 
     setup_systick(&mut cp.SYST);
 
     defmt::info!("Enabling ethernet...");
     let (eth_pins, mdio, mdc, _) = common::setup_pins(gpio);
 
-    let mut rx_ring: [RxRingEntry; 2] = Default::default();
-    let mut tx_ring: [TxRingEntry; 2] = Default::default();
     let Parts {
         mut dma,
         mac,

--- a/examples/rtic-echo.rs
+++ b/examples/rtic-echo.rs
@@ -72,7 +72,8 @@ mod app {
         let rx_ring = cx.local.rx_ring;
         let tx_ring = cx.local.tx_ring;
 
-        let (clocks, gpio, ethernet) = crate::common::setup_peripherals(p);
+        let (clocks, gpio, ethernet) =
+            crate::common::setup_peripherals_and_cache(p, core.MPU, rx_ring, tx_ring);
         let mono = Systick::new(core.SYST, clocks.hclk().raw());
 
         let (rx_storage, tx_storage, socket_storage) = (

--- a/examples/rtic-timestamp.rs
+++ b/examples/rtic-timestamp.rs
@@ -77,7 +77,8 @@ mod app {
         let rx_ring = cx.local.rx_ring;
         let tx_ring = cx.local.tx_ring;
 
-        let (clocks, gpio, ethernet) = crate::common::setup_peripherals(p);
+        let (clocks, gpio, ethernet) =
+            crate::common::setup_peripherals_and_cache(p, core.MPU, rx_ring, tx_ring);
         let mono = Systick::new(core.SYST, clocks.hclk().raw());
 
         defmt::info!("Setting up pins");

--- a/examples/smoltcp-timesync/client.rs
+++ b/examples/smoltcp-timesync/client.rs
@@ -112,7 +112,8 @@ mod app {
         let tx_payload_storage = cx.local.tx_payload_storage;
         let sockets = cx.local.sockets;
 
-        let (clocks, gpio, ethernet) = crate::common::setup_peripherals(p);
+        let (clocks, gpio, ethernet) =
+            crate::common::setup_peripherals_and_cache(p, core.MPU, rx_ring, tx_ring);
         let mono = Systick::new(core.SYST, clocks.hclk().raw());
 
         defmt::info!("Setting up pins");

--- a/examples/smoltcp-timesync/server.rs
+++ b/examples/smoltcp-timesync/server.rs
@@ -81,7 +81,8 @@ mod app {
         let tx_payload_storage = cx.local.tx_payload_storage;
         let sockets = cx.local.sockets;
 
-        let (clocks, gpio, ethernet) = crate::common::setup_peripherals(p);
+        let (clocks, gpio, ethernet) =
+            crate::common::setup_peripherals_and_cache(p, core.MPU, rx_ring, tx_ring);
         let mono = Systick::new(core.SYST, clocks.hclk().raw());
 
         defmt::info!("Setting up pins");

--- a/examples/timesync/client.rs
+++ b/examples/timesync/client.rs
@@ -123,7 +123,8 @@ mod app {
         let rx_ring = cx.local.rx_ring;
         let tx_ring = cx.local.tx_ring;
 
-        let (clocks, gpio, ethernet) = crate::common::setup_peripherals(p);
+        let (clocks, gpio, ethernet) =
+            crate::common::setup_peripherals_and_cache(p, core.MPU, rx_ring, tx_ring);
         let mono = Systick::new(core.SYST, clocks.hclk().raw());
 
         defmt::info!("Setting up pins");

--- a/examples/timesync/server.rs
+++ b/examples/timesync/server.rs
@@ -61,7 +61,8 @@ mod app {
         let rx_ring = cx.local.rx_ring;
         let tx_ring = cx.local.tx_ring;
 
-        let (clocks, gpio, ethernet) = crate::common::setup_peripherals(p);
+        let (clocks, gpio, ethernet) =
+            crate::common::setup_peripherals_and_cache(p, core.MPU, rx_ring, tx_ring);
         let mono = Systick::new(core.SYST, clocks.hclk().raw());
 
         defmt::info!("Setting up pins");


### PR DESCRIPTION
It seems that (part of) the problem in #105 could, in fact, be caching.

To prevent the examples from doing the same, we can set up the MPU to make all of the RAM used by the examples non-cacheable