### PR TITLE
rx: always consume current entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Fix a bug where errors on receive could cause RX stalls ([#108])
+
+[#108]: https://github.com/stm32-rs/stm32-eth/pull/108
+
 ## [0.8.2](https://github.com/stm32-rs/stm32-eth/tree/v0.8.2)
 * Implement `smoltcp::phy::Device` for non-borrowed `EthernetDMA` ([#106])
 

--- a/src/dma/rx/mod.rs
+++ b/src/dma/rx/mod.rs
@@ -148,10 +148,8 @@ impl<'a> RxRing<'a> {
         let entry = &mut self.entries[entry_num];
 
         if entry.is_available() {
-            let length = entry.recv(packet_id)?;
-
             self.next_entry = (self.next_entry + 1) % entries_len;
-
+            let length = entry.recv(packet_id)?;
             Ok((entry_num, length))
         } else {
             Err(RxError::WouldBlock)


### PR DESCRIPTION
The previous code would check if an entry could be received, and _then_ increase the `next_entry` counter.

However, even if reception of a packet/descriptor fails, the DMA will continue along the ring. So, performing the operations in this order would have caused a stall of the RX ring until it was filled.

Increasing the entry number before checking for errors will ensure that the RX ring will continue in lockstep with the DMA.
