### PR TITLE
encapsulate Buffer access

### DIFF
--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -291,11 +291,11 @@ impl<'rx, 'tx> EthernetDMA<'rx, 'tx> {
     /// Prepare a packet for sending.
     ///
     /// See [`TxRing::prepare_packet`].
-    pub async fn prepare_packet<'borrow>(
-        &'borrow mut self,
+    pub async fn prepare_packet(
+        &'_ mut self,
         length: usize,
         packet_id: Option<PacketId>,
-    ) -> TxPacket<'borrow, 'tx> {
+    ) -> TxPacket<'_> {
         self.tx_ring.prepare_packet(length, packet_id).await
     }
 

--- a/src/dma/ring.rs
+++ b/src/dma/ring.rs
@@ -1,31 +1,58 @@
-use super::{rx::RxDescriptor, tx::TxDescriptor, MTU};
+use super::{rx::RxDescriptor, tx::TxDescriptor};
+
+use buffer::Buffer;
 
 pub trait RingDescriptor {
     fn setup(&mut self, buffer: *const u8, len: usize, next: Option<&Self>);
 }
+mod buffer {
+    use core::cell::UnsafeCell;
 
-#[repr(C, align(8))]
-pub struct Buffer {
-    buffer: [u8; MTU],
-}
+    use crate::dma::MTU;
 
-impl Buffer {
-    pub const fn new() -> Self {
-        Self { buffer: [0; MTU] }
+    #[repr(C, align(8))]
+    pub struct Buffer {
+        buffer: UnsafeCell<[u8; MTU]>,
     }
-}
 
-impl core::ops::Deref for Buffer {
-    type Target = [u8; MTU];
+    impl Buffer {
+        pub const fn new() -> Self {
+            Self {
+                buffer: UnsafeCell::new([0u8; _]),
+            }
+        }
 
-    fn deref(&self) -> &Self::Target {
-        &self.buffer
-    }
-}
+        pub const fn len(&self) -> usize {
+            MTU
+        }
 
-impl core::ops::DerefMut for Buffer {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.buffer
+        pub fn as_mut_ptr(&mut self) -> *mut u8 {
+            &raw mut self.buffer as _
+        }
+
+        /// # Safety
+        /// The caller must guarantee that the DMA does not
+        /// own this buffer for the duration of the borrow.
+        pub unsafe fn get(&self) -> &[u8; MTU] {
+            // SAFETY: the shared reference to `self` guarantees
+            // that we have shared access to the buffer for the
+            // lifetime of `self` (which is what we're returning).
+            // The caller guarantees that the DMA does
+            // not own the buffer.
+            unsafe { &*self.buffer.get() }
+        }
+
+        /// # Safety
+        /// The caller must guarantee that the DMA does not
+        /// own this buffer for the duration of the borrow.
+        pub unsafe fn get_mut(&mut self) -> &mut [u8; MTU] {
+            // SAFETY: the exclusive reference to `self` guarantees
+            // that no other borrows of the buffer currently exist
+            // and will not for the lifetime of `self`.
+            // The caller guarantees that the DMA does not
+            // own the buffer.
+            unsafe { &mut *self.buffer.get() }
+        }
     }
 }
 
@@ -33,7 +60,7 @@ impl core::ops::DerefMut for Buffer {
 #[repr(C, align(8))]
 pub struct RingEntry<T: RingDescriptor> {
     desc: T,
-    buffer: Buffer,
+    pub(crate) buffer: Buffer,
 }
 
 impl<T: RingDescriptor + Default> Default for RingEntry<T> {
@@ -73,7 +100,7 @@ impl RingEntry<RxDescriptor> {
 
 impl<T: RingDescriptor> RingEntry<T> {
     pub(crate) fn setup(&mut self, next: Option<&Self>) {
-        let buffer = self.buffer.as_ptr();
+        let buffer = self.buffer.as_mut_ptr();
         let len = self.buffer.len();
         self.desc_mut()
             .setup(buffer, len, next.map(|next| next.desc()));
@@ -87,15 +114,5 @@ impl<T: RingDescriptor> RingEntry<T> {
     #[inline]
     pub(crate) fn desc_mut(&mut self) -> &mut T {
         &mut self.desc
-    }
-
-    #[inline]
-    pub(crate) fn as_slice(&self) -> &[u8] {
-        &(*self.buffer)[..]
-    }
-
-    #[inline]
-    pub(crate) fn as_mut_slice(&mut self) -> &mut [u8] {
-        &mut (*self.buffer)[..]
     }
 }

--- a/src/dma/rx/mod.rs
+++ b/src/dma/rx/mod.rs
@@ -129,7 +129,9 @@ impl<'a> RxRing<'a> {
         self.entries[self.next_entry].is_available()
     }
 
-    /// Receive the next packet (if any is ready).
+    /// If the next ring entry is [`RxRingEntry::is_available`], advance
+    /// the next entry index, and return its `(index, length)`, or an error
+    /// if the entry has errors.
     ///
     /// This function returns a tuple of `Ok((entry_index, length))` on
     /// success. Whoever receives the `Ok` must ensure that `set_owned`
@@ -235,13 +237,19 @@ impl<'a> core::ops::Deref for RxPacket<'a> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
-        &self.entry.as_slice()[0..self.length]
+        // SAFETY: an `RxPacket` is only created
+        // when the associated entry is not owned
+        // by the DMA.
+        unsafe { &self.entry.buffer.get()[0..self.length] }
     }
 }
 
 impl<'a> core::ops::DerefMut for RxPacket<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.entry.as_mut_slice()[0..self.length]
+        // SAFETY: an `RxPacket` is only created
+        // when the associated entry is not owned
+        // by the DMA.
+        unsafe { &mut self.entry.buffer.get_mut()[0..self.length] }
     }
 }
 

--- a/src/dma/tx/descriptor.rs
+++ b/src/dma/tx/descriptor.rs
@@ -187,16 +187,6 @@ impl TxRingEntry {
     pub(super) fn send(&mut self, length: usize, packet_id: Option<PacketId>) {
         self.desc_mut().set_owned(length, packet_id);
     }
-
-    /// Only call this if [`TxRingEntry::is_available`]
-    pub fn buffer(&self) -> &[u8] {
-        self.as_slice()
-    }
-
-    /// Only call this if [`TxRingEntry::is_available`]
-    pub fn buffer_mut(&mut self) -> &mut [u8] {
-        self.as_mut_slice()
-    }
 }
 
 #[cfg(feature = "ptp")]

--- a/src/dma/tx/mod.rs
+++ b/src/dma/tx/mod.rs
@@ -83,7 +83,8 @@ impl<'ring> TxRing<'ring> {
         self.entries[self.next_entry].is_available()
     }
 
-    /// Check if we can send the next TX entry.
+    /// Check if we can send the next TX entry. Returns the first
+    /// [`TxRingEntry::is_available`] entry.
     ///
     /// If [`Ok(res)`] is returned, the caller of must ensure
     /// that [`self.entries[res].send()`](TxRingEntry::send) is called
@@ -109,19 +110,19 @@ impl<'ring> TxRing<'ring> {
     ///
     /// When all data is copied into the TX buffer, use [`TxPacket::send()`]
     /// to transmit it.
-    pub fn send_next<'borrow>(
-        &'borrow mut self,
+    pub fn send_next(
+        &'_ mut self,
         length: usize,
         packet_id: Option<PacketId>,
-    ) -> Result<TxPacket<'borrow, 'ring>, TxError> {
+    ) -> Result<TxPacket<'_>, TxError> {
         let entry = self.send_next_impl()?;
-        let tx_buffer = self.entries[entry].buffer_mut();
+        let entry = &mut self.entries[entry];
+        let tx_buffer = unsafe { entry.buffer.get() };
 
         assert!(length <= tx_buffer.len(), "Not enough space in TX buffer");
 
         Ok(TxPacket {
-            ring: self,
-            idx: entry,
+            entry,
             length,
             packet_id,
         })
@@ -136,11 +137,11 @@ impl<'ring> TxRing<'ring> {
     /// When all data is copied into the TX buffer, use [`TxPacket::send()`]
     /// to transmit it.
     #[cfg(feature = "async-await")]
-    pub async fn prepare_packet<'borrow>(
-        &'borrow mut self,
+    pub async fn prepare_packet(
+        &'_ mut self,
         length: usize,
         packet_id: Option<PacketId>,
-    ) -> TxPacket<'borrow, 'ring> {
+    ) -> TxPacket<'_> {
         let entry = core::future::poll_fn(|ctx| match self.send_next_impl() {
             Ok(packet) => Poll::Ready(packet),
             Err(_) => {
@@ -150,12 +151,14 @@ impl<'ring> TxRing<'ring> {
         })
         .await;
 
-        let tx_buffer = self.entries[entry].buffer_mut();
+        let entry = &mut self.entries[entry];
+        // SAFETY: `send_next_impl` only returns indices for available
+        // entries.
+        let tx_buffer = unsafe { entry.buffer.get() };
         assert!(length <= tx_buffer.len(), "Not enough space in TX buffer");
 
         TxPacket {
-            ring: self,
-            idx: entry,
+            entry,
             length,
             packet_id,
         }
@@ -163,7 +166,7 @@ impl<'ring> TxRing<'ring> {
 
     /// Demand that the DMA engine polls the current `TxDescriptor`
     /// (when we just transferred ownership to the hardware).
-    pub(crate) fn demand_poll(&self) {
+    pub(crate) fn demand_poll() {
         // SAFETY: we only perform an atomic write to `dmatpdr`
         let eth_dma = unsafe { &*ETHERNET_DMA::ptr() };
         eth_dma.dmatpdr.write(|w| {
@@ -308,37 +311,40 @@ impl RunningState {
 ///
 /// [`Deref`]: core::ops::Deref
 /// [`DerefMut`]: core::ops::DerefMut
-pub struct TxPacket<'borrow, 'ring> {
-    ring: &'borrow mut TxRing<'ring>,
-    idx: usize,
+pub struct TxPacket<'borrow> {
+    entry: &'borrow mut TxRingEntry,
     length: usize,
     packet_id: Option<PacketId>,
 }
 
-impl core::ops::Deref for TxPacket<'_, '_> {
+impl core::ops::Deref for TxPacket<'_> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
-        &self.ring.entries[self.idx].buffer()[..self.length]
+        // SAFETY: TxPackets are only created from
+        // available entries.
+        unsafe { self.entry.buffer.get() }
     }
 }
 
-impl core::ops::DerefMut for TxPacket<'_, '_> {
+impl core::ops::DerefMut for TxPacket<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.ring.entries[self.idx].buffer_mut()[..self.length]
+        // SAFETY: TxPackets are only created from
+        // available entries.
+        unsafe { self.entry.buffer.get_mut() }
     }
 }
 
-impl TxPacket<'_, '_> {
+impl TxPacket<'_> {
     /// Send this packet!
     pub fn send(self) {
         drop(self);
     }
 }
 
-impl Drop for TxPacket<'_, '_> {
+impl Drop for TxPacket<'_> {
     fn drop(&mut self) {
-        self.ring.entries[self.idx].send(self.length, self.packet_id.clone());
-        self.ring.demand_poll();
+        self.entry.send(self.length, self.packet_id.clone());
+        TxRing::demand_poll();
     }
 }


### PR DESCRIPTION
As access to `Buffer`s is shared with the DMA,
we cannot simply use (non-)shared references:
the compiler could optimize things in unforseen
ways if it believes that it holds exclusive references to the data buffer.

Encapsulate access to the `Buffer` more strictly and only access it through an `UnsafeCell`.